### PR TITLE
version 20190702

### DIFF
--- a/amd64+firmwares/config/hooks/live/99root.hook.chroot
+++ b/amd64+firmwares/config/hooks/live/99root.hook.chroot
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo root:lzk | /usr/sbin/chpasswd

--- a/amd64+firmwares/config/package-lists/librazik.list.chroot
+++ b/amd64+firmwares/config/package-lists/librazik.list.chroot
@@ -24,3 +24,10 @@ linux-image-4.9.0-9-lzk-bl-amd64
 
 alsa-firmware-loaders
 iucode-tool
+
+# paquets logiciels oubliés dans librazik-base-logicielsaudiomidi
+
+bambootracker
+bamp
+bslizr
+shiro-plugins

--- a/i386+firmwares/config/hooks/live/99root.hook.chroot
+++ b/i386+firmwares/config/hooks/live/99root.hook.chroot
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo root:lzk | /usr/sbin/chpasswd

--- a/i386+firmwares/config/package-lists/librazik.list.chroot
+++ b/i386+firmwares/config/package-lists/librazik.list.chroot
@@ -24,3 +24,10 @@ linux-image-4.9.0-9-lzk-bl-686-pae
 
 alsa-firmware-loaders
 iucode-tool
+
+# paquets logiciels oubliés dans librazik-base-logicielsaudiomidi
+
+bambootracker
+bamp
+bslizr
+shiro-plugins


### PR DESCRIPTION
- suppression du mot de passe root du live (qui était conservé sur un système installé même si l'utilisateur en avait mis un autre lors du processus d'installation)
- ajout de paquets logiciels MAO oubliés dans librazik-base-logicielsaudiomidi
